### PR TITLE
fix(home): keep onboard progress percent in sync + show contract rows for unsigned

### DIFF
--- a/app/lib/components/onboard_progress_box/onboard_progress_box_widget.dart
+++ b/app/lib/components/onboard_progress_box/onboard_progress_box_widget.dart
@@ -51,19 +51,42 @@ class _OnboardProgressBoxWidgetState extends State<OnboardProgressBoxWidget> {
 
     // On component load action.
     SchedulerBinding.instance.addPostFrameCallback((_) async {
-      _model.actionsDonePercent = functions.onboardingActionsDonePercent(
-          FFAppState().solarContractSigned,
-          FFAppState().supplyContractSigned,
-          widget.haveSolarContract!,
-          widget.haveSupplyContract!,
-          widget.hasPaymentMethod!,
-          widget.confirmedDetails!,
-          widget.isOccupier,
-          widget.isOwner)!;
+      _model.actionsDonePercent = _computeActionsDonePercent();
       safeSetState(() {});
     });
 
     WidgetsBinding.instance.addPostFrameCallback((_) => safeSetState(() {}));
+  }
+
+  /// Recomputes the onboard progress percentage from the current widget
+  /// props and FFAppState contract flags.
+  ///
+  /// Called on every rebuild (see [build]). This is the fix for the
+  /// "100% with 2 contracts unsigned" bug:
+  ///
+  /// On first mount, `HomePage.initState` schedules `setContractStatusFlags`
+  /// in a post-frame callback. That flips `FFAppState.haveSupplyContract` /
+  /// `haveSolarContract` from false to true and triggers a rebuild. The
+  /// old code only computed the percent once inside this widget's
+  /// `initState` (also in a post-frame callback, racing with the parent's),
+  /// so it was pinned to a snapshot taken when only 3 conditional items
+  /// were visible (invitation + confirm details + payment method). After
+  /// the rebuild the two "Sign your ... contract" rows appeared but the
+  /// percent stayed at 100% because `initState` does not re-run.
+  ///
+  /// Doing the math on every rebuild keeps the donut in sync with the
+  /// row check-states below it. The function is a few `bool` operations
+  /// so the cost is negligible.
+  double _computeActionsDonePercent() {
+    return functions.onboardingActionsDonePercent(
+        FFAppState().solarContractSigned,
+        FFAppState().supplyContractSigned,
+        widget.haveSolarContract!,
+        widget.haveSupplyContract!,
+        widget.hasPaymentMethod!,
+        widget.confirmedDetails!,
+        widget.isOccupier,
+        widget.isOwner)!;
   }
 
   @override
@@ -76,6 +99,11 @@ class _OnboardProgressBoxWidgetState extends State<OnboardProgressBoxWidget> {
   @override
   Widget build(BuildContext context) {
     context.watch<FFAppState>();
+
+    // Recompute on every rebuild so the donut always matches the row
+    // check-states below. See `_computeActionsDonePercent` for the full
+    // explanation.
+    _model.actionsDonePercent = _computeActionsDonePercent();
 
     return Column(
       mainAxisSize: MainAxisSize.max,

--- a/app/lib/pages/home_page/home_page_widget.dart
+++ b/app/lib/pages/home_page/home_page_widget.dart
@@ -901,9 +901,19 @@ class _HomePageWidgetState extends State<HomePageWidget> {
                                                 ),
                                                 decoration: const BoxDecoration(),
                                                 child: Visibility(
-                                                  visible: FFAppState()
-                                                          .supplyContractSigned &&
-                                                      (FFAppState()
+                                                  // Show the supply contract card whenever a supply
+                                                  // contract exists for this property — not only when
+                                                  // it is signed. Previously the row was gated on
+                                                  // `supplyContractSigned`, which made it impossible
+                                                  // to sign from the home page once the onboard
+                                                  // progress box was hidden (e.g. for users who skip
+                                                  // onboarding, or for any future flow where the
+                                                  // user is not in preonboarding/onboarding/pending).
+                                                  // The "View" button on the row opens the signing
+                                                  // modal for unsigned contracts and the signed PDF
+                                                  // for signed ones — see `openSupplyContract` in
+                                                  // actions.dart.
+                                                  visible: (FFAppState()
                                                               .supplyAccount
                                                               .customerAccount
                                                               .role ==
@@ -1572,13 +1582,21 @@ class _HomePageWidgetState extends State<HomePageWidget> {
                                                     ),
                                                     decoration: const BoxDecoration(),
                                                     child: Visibility(
-                                                      visible: FFAppState()
-                                                              .solarContractSigned &&
-                                                          (FFAppState()
+                                                      // Show the solar contract card whenever a solar
+                                                      // contract exists for this property — not only
+                                                      // when it is signed. See the matching comment on
+                                                      // the supply contract card above for the reason.
+                                                      visible: (FFAppState()
                                                                   .solarAccount
                                                                   .customerAccount
                                                                   .role ==
-                                                              'owner'),
+                                                              'owner') &&
+                                                          (functions.getContractByType(
+                                                                  FFAppState()
+                                                                      .accountsForCurrentProperty
+                                                                      .toList(),
+                                                                  'solar') !=
+                                                              null),
                                                       child: Card(
                                                         clipBehavior: Clip
                                                             .antiAliasWithSaveLayer,


### PR DESCRIPTION
Two related fixes on the home page (ownocc12-style accounts):

**1. Onboard progress stuck at 100% with 2 unsigned contracts**

Root cause: `OnboardProgressBoxWidget` computed `_model.actionsDonePercent` exactly once in its `initState` post-frame callback. On first mount, `FFAppState.haveSupplyContract` / `haveSolarContract` are still false — `setContractStatusFlags` is scheduled in the home page's own post-frame callback and hasn't run yet. With those false but `isOccupier` / `isOwner` true and `hasPaymentMethod` / `confirmedDetails` true, the math lands at 3/3 = 100%. After the parent rebuilds with fresh flags, the two 'Sign your ... contract' rows appear (unchecked) but the percent stays pinned at 100% because `initState` doesn't re-run. A manual page reload works because `FFAppState` is already populated from prefs by then.

Fix: recompute `_model.actionsDonePercent` in `build()` on every rebuild (extracted into `_computeActionsDonePercent()` with a doc comment). The function is a handful of bool ops so the cost is negligible.

**2. Contract rows under supply / solar boxes hidden until signed**

The `Visibility` conditions on `home_page_widget.dart` required `supplyContractSigned` / `solarContractSigned`, so users whose onboard box is hidden (status not in preonboarding/onboarding/pending) had no way to sign a contract from the home page. Dropped the signed requirement — the row is shown whenever a contract exists. The 'View' button routes through `openSupplyContract` / `openSolarContract` which already handle both signed (open PDF) and unsigned (open signing modal) cases.

**Verified**
- `fvm flutter analyze` on changed files: no new warnings.
- `fvm flutter test`: 6/6 pass.
- Local stack: queried `ownocc12@wl.ce` directly to confirm DB state (status=onboarding, confirmed_details_at set, has_payment_method=t, both contracts unsigned). Verified the 100%/60% divergence with a Dart simulation against the function.