### PR TITLE
Rename Flutter app references to simt-j-myenergyservice (PR 3)

### DIFF
--- a/app/lib/config/app_config.dart
+++ b/app/lib/config/app_config.dart
@@ -12,7 +12,7 @@ abstract class AppConfig {
   String get flutterVersion =>
       const String.fromEnvironment('BUILD_FLUTTER_VERSION', defaultValue: 'unknown');
 
-  // see simt-j-accounts-service - the myenergy / accounts service
+  // see simt-j-myenergyservice - the myenergy service
   String get myenergyServiceURI;
 
   // self hosted supabase

--- a/app/lib/config/prod_config.dart
+++ b/app/lib/config/prod_config.dart
@@ -4,7 +4,7 @@ class ProdConfig extends AppConfig {
   ProdConfig() : super('prod');
 
   @override
-  String get myenergyServiceURI => "https://simt-j-accounts-mgf.fly.dev";
+  String get myenergyServiceURI => "https://simt-j-myenergy-mgf.fly.dev";
 
   @override
   String get supabaseURI => "https://supabase-kong-mgf.fly.dev";

--- a/app/lib/pages/sys_info_page/sys_info_page_widget.dart
+++ b/app/lib/pages/sys_info_page/sys_info_page_widget.dart
@@ -451,7 +451,7 @@ class _SysInfoPageWidgetState extends State<SysInfoPageWidget> {
                                                     color: Colors.transparent,
                                                     child: ListTile(
                                                       title: Text(
-                                                        'simt-j-accounts URI',
+                                                        'myenergyservice URI',
                                                         style:
                                                             FlutterFlowTheme.of(
                                                                     context)


### PR DESCRIPTION
## Rename Flutter app references to simt-j-myenergyservice

PR 3 of the `simt-j-accountservice` → `simt-j-myenergyservice` rename
plan (see `workspace-simt/specs/accounts-service-rename-plan.md`,
section 1.8).

### Changes

Three Flutter app edits, all consistent with the new
`myenergyservice` name on the wire:

| File | Change |
|---|---|
| `app/lib/config/prod_config.dart:7` | `myenergyServiceURI` now points at `https://simt-j-myenergy-mgf.fly.dev` |
| `app/lib/config/app_config.dart:15` | stale `// see simt-j-accounts-service` comment updated to `// see simt-j-myenergyservice` |
| `app/lib/pages/sys_info_page/sys_info_page_widget.dart:454` | sysinfo label `'simt-j-accounts URI'` → `'myenergyservice URI'` |

Diff is `+3 / -3` lines across three files.

### Out of scope

- HTTP path mappings (`/customer`, `/admin`, `/stripe/webhook/...`,
  `/docuseal/webhook/...`, `/contract/...`, `/events/stream`) — these
  are domain concepts (account records, billing endpoints), not
  service-named, and stay put per the rename plan.
- GraphQL documents (`accounts.graphql`, `customerAccounts.graphql`)
  — query names refer to *account records*, not the service.
- The Flutter rebuild and tag push (`*-wlce` / `*-hmce`) — that
  happens in a separate step after this PR merges, per the plan.

### Validation

- `dart analyze` (the `bin/pre-commit` hook) passes — no new issues
  in the three touched files.
- Working tree clean, pushed to `origin/rename/myenergyservice-uri`.

### Related

- Rename plan: `workspace-simt/specs/accounts-service-rename-plan.md`
- PR 2 (shipped): filesystem + Fly config rename in the Java service
  repo, `cepro/simt-j-myenergyservice`
- Manual steps that follow this PR merge:
  - Cut a Flutter build (`bin/build-fly`) and tag (`bin/tag-release`)
    to deploy the new URI to `wlce`/`hmce`.
  - Verify the sysinfo page on a phone (or `--dart-define=ENV=prod`
    build) shows the new URI.