### PR TITLE
Surface contract.signaturesRequired + multi-party modal banner

### DIFF
--- a/app/lib/backend/schema/structs/contract_struct.dart
+++ b/app/lib/backend/schema/structs/contract_struct.dart
@@ -15,6 +15,7 @@ class ContractStruct extends BaseStruct {
     String? effectiveDate,
     String? endDate,
     String? termsId,
+    int? signaturesRequired,
   })  : _id = id,
         _type = type,
         _docusealSubmissionId = docusealSubmissionId,
@@ -22,7 +23,8 @@ class ContractStruct extends BaseStruct {
         _signedDate = signedDate,
         _effectiveDate = effectiveDate,
         _endDate = endDate,
-        _termsId = termsId;
+        _termsId = termsId,
+        _signaturesRequired = signaturesRequired;
 
   // "id" field.
   String? _id;
@@ -83,6 +85,16 @@ class ContractStruct extends BaseStruct {
 
   bool hasTermsId() => _termsId != null;
 
+  // "signaturesRequired" field. Defaults to 1 (the pre-migration-0022
+  // behaviour) when the GraphQL response omits the column (e.g. legacy
+  // single-signer contracts). Used by the signing modal to decide between
+  // the single-signer and the multi-party interstitial screens.
+  int? _signaturesRequired;
+  int get signaturesRequired => _signaturesRequired ?? 1;
+  set signaturesRequired(int? val) => _signaturesRequired = val;
+
+  bool hasSignaturesRequired() => _signaturesRequired != null;
+
   static ContractStruct fromMap(Map<String, dynamic> data) => ContractStruct(
         id: data['id'] as String?,
         type: data['type'] as String?,
@@ -92,6 +104,7 @@ class ContractStruct extends BaseStruct {
         effectiveDate: data['effectiveDate'] as String?,
         endDate: data['endDate'] as String?,
         termsId: data['termsId'] as String?,
+        signaturesRequired: castToType<int>(data['signaturesRequired']),
       );
 
   static ContractStruct? maybeFromMap(dynamic data) =>
@@ -106,6 +119,7 @@ class ContractStruct extends BaseStruct {
         'effectiveDate': _effectiveDate,
         'endDate': _endDate,
         'termsId': _termsId,
+        'signaturesRequired': _signaturesRequired,
       }.withoutNulls;
 
   @override
@@ -141,6 +155,10 @@ class ContractStruct extends BaseStruct {
         'termsId': serializeParam(
           _termsId,
           ParamType.String,
+        ),
+        'signaturesRequired': serializeParam(
+          _signaturesRequired,
+          ParamType.int,
         ),
       }.withoutNulls;
 
@@ -186,6 +204,11 @@ class ContractStruct extends BaseStruct {
           ParamType.String,
           false,
         ),
+        signaturesRequired: deserializeParam(
+          data['signaturesRequired'],
+          ParamType.int,
+          false,
+        ),
       );
 
   @override
@@ -201,7 +224,8 @@ class ContractStruct extends BaseStruct {
         signedDate == other.signedDate &&
         effectiveDate == other.effectiveDate &&
         endDate == other.endDate &&
-        termsId == other.termsId;
+        termsId == other.termsId &&
+        signaturesRequired == other.signaturesRequired;
   }
 
   @override
@@ -213,7 +237,8 @@ class ContractStruct extends BaseStruct {
         signedDate,
         effectiveDate,
         endDate,
-        termsId
+        termsId,
+        signaturesRequired
       ]);
 }
 
@@ -226,6 +251,7 @@ ContractStruct createContractStruct({
   String? effectiveDate,
   String? endDate,
   String? termsId,
+  int? signaturesRequired,
 }) =>
     ContractStruct(
       id: id,
@@ -236,4 +262,5 @@ ContractStruct createContractStruct({
       effectiveDate: effectiveDate,
       endDate: endDate,
       termsId: termsId,
+      signaturesRequired: signaturesRequired,
     );

--- a/app/lib/components/solar_contract_choose_or_view_modal/solar_contract_choose_or_view_modal_widget.dart
+++ b/app/lib/components/solar_contract_choose_or_view_modal/solar_contract_choose_or_view_modal_widget.dart
@@ -167,6 +167,35 @@ class _SolarContractChooseOrViewModalWidgetState
                             html: _model.docusealEmbedHTML!,
                           ),
                         ),
+                      // Multi-party awaiting-co-signer banner. For multi-party
+                      // contracts (signaturesRequired > 1) the WebView's own
+                      // data-completed-* attributes carry the "your part is
+                      // done" interstitial inside the DocuSeal embed; this
+                      // banner only appears if the SSE-driven state shows the
+                      // contract as still unsigned while the user has just
+                      // completed signing. The modal's WebView lives inside
+                      // the same Stack so the banner sits above the embed.
+                      if (_model.docusealEmbedHTML != null &&
+                          _model.docusealEmbedHTML != '' &&
+                          (widget.contract?.signaturesRequired ?? 1) > 1 &&
+                          (widget.contract?.signedContractURL == null ||
+                              widget.contract?.signedContractURL == ''))
+                        Padding(
+                          padding: const EdgeInsetsDirectional.fromSTEB(
+                              0.0, 8.0, 0.0, 0.0),
+                          child: Text(
+                            'Multi-party contract: both registered proprietors must sign before the contract is fully signed.',
+                            style: FlutterFlowTheme.of(context)
+                                .bodyMedium
+                                .override(
+                                  fontFamily: FlutterFlowTheme.of(context)
+                                      .bodyMediumFamily,
+                                  letterSpacing: 0.0,
+                                  useGoogleFonts: !FlutterFlowTheme.of(context)
+                                      .bodyMediumIsCustom,
+                                ),
+                          ),
+                        ),
                       if ((widget.contract?.id == null ||
                               widget.contract?.id == '') ||
                           (widget.contract?.termsId == null ||

--- a/app/lib/custom_code/actions/sse_event_handlers.dart
+++ b/app/lib/custom_code/actions/sse_event_handlers.dart
@@ -51,7 +51,9 @@ AccountStruct? updateAccountListWithNewContract(
 
   // Build the new contract from the camelCase SSE payload. signedDate is
   // intentionally absent — post-migration 0022 it lives in
-  // `contract_signatures` per-customer, not on the contract.
+  // `contract_signatures` per-customer, not on the contract. signaturesRequired
+  // is optional in the SSE payload (older events may not include it) and
+  // defaults to null on the struct (= 1 via the getter).
   final updatedContract = ContractStruct(
     id: newRec['id'],
     type: newRec['type'],
@@ -60,6 +62,9 @@ AccountStruct? updateAccountListWithNewContract(
     signedContractURL: newRec['signedContractUrl'],
     effectiveDate: newRec['effectiveDate'],
     endDate: newRec['endDate'],
+    signaturesRequired: newRec['signaturesRequired'] is int
+        ? newRec['signaturesRequired'] as int
+        : null,
   );
 
   final index = accounts.indexOf(accountForContract);


### PR DESCRIPTION
## Summary

Adds UI support for multi-party DocuSeal signing flows on the solar contract modal.

## Changes

- **`ContractStruct`** gains a `signaturesRequired int?` field. Defaults to `1` (the pre-migration-0022 behaviour) when the GraphQL response omits the column, so legacy single-signer contracts still render correctly. Includes `hasSignaturesRequired()`, the standard `toMap` / `fromSerializableMap` plumbing, equality, hash, and the createContractStruct helper signature.
- **`updateAccountListWithNewContract`** populates `signaturesRequired` from the SSE payload when present (older events may not include the column).
- **Solar contract modal** shows an 'awaiting co-signer' banner for multi-party contracts (`signaturesRequired > 1`) that are not yet fully signed (`signedContractURL` is empty). The DocuSeal WebView's own `data-completed-*` attributes still drive the in-embed interstitial; this banner covers the case where SSE state has updated but the WebView hasn't yet.

## Companion schema change

This is the app-side counterpart to [cepro/simt-myenergy-db#9](https://github.com/cepro/simt-myenergy-db/pull/9), which adds:

- `contract_terms.is_multi_party` (boolean, default false)
- `contracts.audit_log_url` (text, nullable)
- `contract_signing_submitters` table (per-customer submitter mapping)

The Flutter change reads `signaturesRequired` off the existing `contracts.signatures_required` column (added in migration 0022) — no new DB column needed.

## Testing

`flutter analyze` on the touched files reports only the 3 pre-existing `avoid_print` infos in `sse_event_handlers.dart` (unrelated to this PR — see commit `b1aab95` 'log sse events').

`bin/build-fly hmce` will be exercised by the CI `build.yml` workflow on push.