### PR TITLE
ci: dependency scanning, SBOM, Dependabot, SHA pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Dependency update bot. Enables the dependency graph and free security
+# alerts as a side effect (this is a public repo, so all of that is free).
+# See specs/dependency-security-plan.md Phase 1.
+version: 2
+updates:
+  # Flutter / Dart packages. The app lives under /app.
+  - package-ecosystem: "pub"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(flutter)"
+    groups:
+      # The Supabase client family is version-coupled — bundle the whole
+      # set into one PR so a bump never lands piecemeal and breaks compat.
+      # (First matching group wins, so this must come before minor-patch.)
+      supabase:
+        patterns:
+          - "supabase"
+          - "supabase_flutter"
+          - "gotrue"
+          - "realtime_client"
+          - "storage_client"
+          - "functions_client"
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Dockerfile base image (nginx). Dependabot refreshes the pinned digest.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # GitHub Actions referenced from .github/workflows/*. Dependabot bumps the
+  # SHA-pinned actions and keeps the "# vX.Y.Z" comments current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps(ci)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+      time: "06:00"
+      timezone: "Australia/Sydney"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "flutter"
     commit-message:
       prefix: "deps(flutter)"
     groups:
@@ -35,6 +40,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "06:00"
+      timezone: "Australia/Sydney"
+    labels:
+      - "dependencies"
+      - "docker"
     commit-message:
       prefix: "deps(docker)"
 
@@ -45,5 +55,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "06:00"
+      timezone: "Australia/Sydney"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
     commit-message:
       prefix: "deps(ci)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,34 +35,27 @@ jobs:
         run: bin/build-fly hmce
 
   # Phase 2 — full vulnerability sweep of the Dart deps (pubspec.lock).
-  # Fails on HIGH/CRITICAL. NOTE: on the first run this may go red if a
-  # known HIGH vuln already exists in pubspec.lock — fix it, or relax
-  # --fail-on to 'critical'. This is the full sweep; the dependency-review
-  # job below is the diff-only PR gate (they're complementary).
+  # Calls osv-scanner-action's reusable workflow, which runs the scan,
+  # uploads SARIF to Code Scanning itself, and fails when a vuln is found
+  # (fail-on-vuln: true). This is the full sweep; the dependency-review job
+  # below is the diff-only PR gate (they're complementary).
+  #
+  # osv-scanner has NO severity-threshold flag — fail-on-vuln is boolean,
+  # so this fails on ANY vuln, not just HIGH/CRITICAL. Triage findings via
+  # the Security tab; if a build is blocked by an acceptable/low-severity
+  # finding, suppress that specific advisory with an osv-scanner.toml
+  # [[PackageOverrides]] entry. (The image scan in deploy-template.yml uses
+  # trivy, which DOES honor a HIGH/CRITICAL severity filter.)
   dependency-scan:
-    name: Dependency scan (pubspec.lock)
-    runs-on: ubuntu-latest
     permissions:
+      actions: read # required for SARIF upload to Code Scanning
       contents: read
-      security-events: write # upload osv-scanner SARIF to Code Scanning
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: osv-scanner on pubspec.lock
-        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
-        with:
-          scan-args: |-
-            --lockfile=app/pubspec.lock
-            --format=sarif
-            --output=results.sarif
-            --fail-on=high
-
-      - name: Upload SARIF to Code Scanning
-        if: always() # upload even if osv-scanner failed the job
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
-        with:
-          sarif_file: results.sarif
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=app/pubspec.lock
+      fail-on-vuln: true
 
   # Phase 4 — SBOM for the Dart app source (CycloneDX). Uploaded as a
   # workflow artifact (no GitHub Release; see plan Phase 4).
@@ -83,6 +76,11 @@ jobs:
   # Phase 3 — PR gate. Diff-only: fails when changed deps ADD a vuln of the
   # given severity or higher. Does NOT catch vulns in unchanged deps (that
   # is dependency-scan above). Runs on pull requests only.
+  #
+  # PREREQ: requires the repo's Dependency graph to be ON (Settings → Code
+  # security). Until enabled (and this PR merged so .github/dependabot.yml
+  # lands), this job errors with "Dependency review is not supported" —
+  # that's a setting, not a bug.
   dependency-review:
     name: Dependency review (PR gate)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: Build and Test
 
 on:
   push:
+  pull_request:
+    branches: [main]
+
+# Least-privilege defaults. Jobs that need more grant it explicitly.
+permissions:
+  contents: read
 
 jobs:
   build-hmce:
@@ -9,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Read Flutter version
         id: flutter-version
@@ -19,7 +25,7 @@ jobs:
           echo "Flutter version: $FLUTTER_VERSION"
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: 'stable'
@@ -27,3 +33,70 @@ jobs:
 
       - name: Build Flutter app for hmce
         run: bin/build-fly hmce
+
+  # Phase 2 — full vulnerability sweep of the Dart deps (pubspec.lock).
+  # Fails on HIGH/CRITICAL. NOTE: on the first run this may go red if a
+  # known HIGH vuln already exists in pubspec.lock — fix it, or relax
+  # --fail-on to 'critical'. This is the full sweep; the dependency-review
+  # job below is the diff-only PR gate (they're complementary).
+  dependency-scan:
+    name: Dependency scan (pubspec.lock)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload osv-scanner SARIF to Code Scanning
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: osv-scanner on pubspec.lock
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --lockfile=app/pubspec.lock
+            --format=sarif
+            --output=results.sarif
+            --fail-on=high
+
+      - name: Upload SARIF to Code Scanning
+        if: always() # upload even if osv-scanner failed the job
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          sarif_file: results.sarif
+
+  # Phase 4 — SBOM for the Dart app source (CycloneDX). Uploaded as a
+  # workflow artifact (no GitHub Release; see plan Phase 4).
+  app-sbom:
+    name: SBOM (app source)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Generate SBOM with syft
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: app
+          format: cyclonedx-json
+          artifact-name: app.cdx.json
+
+  # Phase 3 — PR gate. Diff-only: fails when changed deps ADD a vuln of the
+  # given severity or higher. Does NOT catch vulns in unchanged deps (that
+  # is dependency-scan above). Runs on pull requests only.
+  dependency-review:
+    name: Dependency review (PR gate)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write # post the failure summary as a PR comment
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Review changed dependencies
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          # Block on HIGH/CRITICAL; MODERATE and below are reported but pass.
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Read Flutter version
         id: flutter-version
@@ -33,7 +33,7 @@ jobs:
           echo "Flutter version: $FLUTTER_VERSION"
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: 'stable'
@@ -46,8 +46,31 @@ jobs:
         id: build_image
         run: docker build -t myenergy:${GITHUB_REF_NAME} .
 
+      # Phase 4 — SBOM for the built image (SPDX). Covers nginx + Alpine OS
+      # packages + the Dart runtime — the surface pubspec.lock can't see.
+      # Uploaded as a workflow artifact (no GitHub Release; see plan Phase 4).
+      - name: Generate image SBOM with syft
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: myenergy:${{ github.ref_name }}
+          format: spdx-json
+          artifact-name: image.spdx.json
+
+      # Phase 2 — scan the built image for nginx + Alpine OS vulns. Fails on
+      # HIGH/CRITICAL, which blocks this deploy. To make it report-only,
+      # add `continue-on-error: true`. ignore-unfixed skips vulns with no
+      # available fix so we don't block deploys on unfixable findings.
+      - name: Scan image with trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: myenergy:${{ github.ref_name }}
+          format: table
+          exit-code: '1'
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: true
+
       - name: Setup Fly CLI
-        uses: superfly/flyctl-actions/setup-flyctl@1.6
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
         with:
           version: 0.4.61
 
@@ -70,7 +93,7 @@ jobs:
           git stash pop
 
       - name: Commit version file
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: 'github action: build number incremented'
           file_pattern: 'app/pubspec.yaml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:alpine
+# nginx 1.31.2-alpine3.23 (mainline), pinned by digest. Dependabot
+# (docker ecosystem) refreshes the digest/version automatically.
+FROM nginx:1.31.2-alpine3.23@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa
 
 # Copy custom nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/specs/dependency-security-plan.md
+++ b/specs/dependency-security-plan.md
@@ -1,0 +1,218 @@
+# Dependency security for simt-myenergy-app
+
+## Status (2026-06-30)
+
+Draft — recommendation-only. No implementation in this document. Decision
+needed on whether to start with Dependabot (path of least resistance) or
+go straight to a Renovate-based setup, and on whether to publish SBOMs
+to GitHub Releases or an internal Dependency-Track.
+
+## Goal
+
+Add dependency vulnerability scanning, a software bill of materials
+(SBOM), and automated dependency update PRs to the `simt-myenergy-app`
+Flutter web app (deployed to Fly.io, CI on GitHub Actions). Today none
+of these exist. The app ships a Docker image based on `nginx:alpine`
+plus a Flutter web build, and pulls ~81 direct deps (~160 entries in
+`app/pubspec.lock` including transitives) — real surface area, no
+scanning.
+
+Why this matters:
+
+- A Flutter `pub` dep with a known CVE has no in-Pub equivalent of
+  `npm audit`. We need an external scanner that reads `pubspec.lock`.
+- The deployed image contains the Flutter engine, Dart SDK output, and
+  the `nginx:alpine` base — neither `pubspec.yaml` nor the Dockerfile
+  alone describes the full supply chain.
+- Without bot scanning, version bumps only happen when a developer
+  manually edits `pubspec.yaml`, which is essentially never for
+  security-only updates.
+
+## What's already in place
+
+| Surface | State |
+|---|---|
+| `app/pubspec.lock` (~160 entries, pinned versions + sha256) | committed |
+| `app/pubspec.yaml` (~81 direct deps, semver `^` ranges) | committed |
+| Repository visibility | **public** (`cepro/simt-myenergy-app`) |
+| `Dockerfile` (`FROM nginx:alpine`, not pinned to digest) | committed |
+| `.github/workflows/build.yml` (CI: `bin/build-fly hmce` on every push) | live, no test step, no audit step |
+| `.github/workflows/deploy.yml` + `deploy-template.yml` (Fly deploy on `*-wlce` / `*-hmce` tag) | live |
+| GitHub Actions pinned to **major tag** (`@v6`, `@v2`, `@1.6`, `@v7`) | live, not SHA-pinned |
+| Dependabot / Renovate config | **none** |
+| OSV / Trivy / Snyk / Grype in CI | **none** |
+| SBOM generation | **none** |
+| GitHub Security tab → Dependabot alerts | off (no Dependabot config) |
+| `bin/upload-sourcemaps-to-sentry` | unrelated (Sentry source maps) |
+
+## Recommended stack
+
+Three layers, each independent and additive:
+
+1. **Bot for updates** — Dependabot (`pub` + `docker` + `github-actions`).
+   Alternative: Renovate if we want richer grouping / auto-merge / a
+   dashboard.
+2. **CI scanning** — `osv-scanner` on `app/pubspec.lock` in `build.yml`
+   and on the built image in `deploy-template.yml` (Dart deps vs. nginx +
+   Alpine OS packages). Pairs with `actions/dependency-review-action` on
+   PRs to block regressions.
+3. **SBOM** — `syft` is the single tool for both surfaces: `syft dir:app`
+   for the Dart app (reads `pubspec.yaml`/`pubspec.lock`) and
+   `syft <image>` (or `trivy image`) for the Docker image. Both emit
+   CycloneDX and SPDX. `cyclonedx-dart` is the alternative if you want a
+   Dart-native generator; syft halves the SBOM tooling. Note: the deploy
+   workflow currently creates **no** GitHub Release — see Phase 4.
+
+### Why these specific tools
+
+| Tool | Why this one |
+|---|---|
+| Dependabot | Native GitHub integration; auto-enables security alerts; first-class `pub` support since 2024; zero cost (and free on public repos). |
+| `osv-scanner` (`google/osv-scanner-action`) | One tool, three surfaces: reads `pubspec.lock`, scans the built **image** (`osv-scanner scan image`), and ingests **SBOMs**; emits SARIF for Code Scanning; free. |
+| `syft` (`anchore/sbom-action`) | Generates SBOMs (CycloneDX + SPDX) from **both** the app source and the image — one tool instead of two. (osv-scanner can scan a syft SBOM directly.) |
+| `trivy image` (`aquasecurity/trivy-action`) | Optional: scans the image with the same tool that generated its SBOM. Redundant once you have syft + osv-scanner; keep only if you prefer it. |
+| `cyclonedx-dart` | Alternative app-SBOM generator, Dart-native. Skipped in favor of syft unless you need its specific output. |
+| `dependency-review-action` | Diff-only: blocks PRs that **introduce** new vulns of chosen severity (regression prevention). Does NOT catch vulns in unchanged deps — that's osv-scanner + Dependabot alerts. |
+
+## Phased adoption (least → most effort)
+
+### Phase 1 — Dependabot config (~10 min)
+
+Add `.github/dependabot.yml` with:
+
+- `package-ecosystem: pub`, `directory: /app`, weekly, group minor + patch
+- `package-ecosystem: docker`, `directory: /`, weekly
+- `package-ecosystem: github-actions`, `directory: /`, weekly
+
+Group the version-coupled Supabase family (`supabase`, `supabase_flutter`,
+`gotrue`, `realtime_client`, `storage_client`, `functions_client`) into a
+single `groups:` block so Dependabot never opens a partial bump that
+breaks their compatibility:
+
+```yaml
+# under the pub ecosystem config
+groups:
+  supabase:
+    patterns:
+      - "supabase"
+      - "supabase_flutter"
+      - "gotrue"
+      - "realtime_client"
+      - "storage_client"
+      - "functions_client"
+```
+
+Enables the GitHub dependency graph and free security alerts as a side
+effect (both free and automatic on a **public** repo).
+
+### Phase 2 — CI vulnerability scan (~20 min)
+
+Split the scan by surface so each workflow does the cheap, relevant
+check — no duplication:
+
+- **`build.yml`** — `osv-scanner` on `app/pubspec.lock` (Dart deps only,
+  runs on every push/PR). Fail on `HIGH`/`CRITICAL` only; upload SARIF
+  via `github/codeql-action/upload-sarif`.
+- **`deploy-template.yml`** — `osv-scanner scan image` (or `trivy image`)
+  on the built `myenergy:<tag>` image. This is the only place that
+  catches `nginx:alpine` + Alpine OS-package vulns — the surface
+  `pubspec.lock` cannot see. Fail `HIGH`/`CRITICAL`.
+
+Add explicit `permissions:` blocks to both: SARIF upload needs
+`security-events: write`; scanning needs `contents: read`. Neither
+workflow has these today (`build.yml` has no `permissions:` block at all).
+
+### Phase 3 — PR gate (~15 min)
+
+Add `actions/dependency-review-action@v4` to a new PR-triggered
+workflow (or extend `build.yml` to also run on
+`pull_request: { branches: [main] }`). Fails when changed deps add a
+vuln above the chosen severity.
+
+Three notes:
+
+- **Yes, add the `pull_request` trigger.** It's what lets the Phase 2
+  osv step also scan Dependabot's own bump PRs — the two are coupled,
+  not independent.
+- **`dependency-review-action` only diffs the PR**, so it catches
+  regressions but not a vuln in an unchanged dep. That full sweep is
+  osv-scanner + Dependabot alerts. They're complementary, not
+  substitutes.
+- Needs `permissions: { contents: read, pull-requests: write }`.
+
+### Phase 4 — SBOM generation (~30–45 min)
+
+- `syft dir:app -o cyclonedx-json` step in `build.yml` → produces
+  `app.cdx.json` for the Dart deps. Upload as a workflow artifact.
+- `syft myenergy:<tag> -o spdx-json` (or `trivy image --format spdx-json`)
+  on the built image in `deploy-template.yml` → produces `image.spdx.json`
+  covering nginx + Alpine OS packages + the Dart runtime. Upload.
+- **No GitHub Release exists today** — `deploy.yml`/`deploy-template.yml`
+  only deploy to Fly and bump the build number. To attach SBOMs to a
+  release you must first add a release step: create a GitHub Release from
+  the `*-hmce`/`*-wlce` tag (e.g. `softprops/action-gh-release`), then
+  attach both SBOMs as release assets. Alternatively, skip the release
+  and keep both SBOMs as workflow artifacts. If/when an internal
+  Dependency-Track exists, push there too — out of scope here.
+
+### Phase 5 — Pin GitHub Actions + Dockerfile base to SHA (~20 min)
+
+Defense in depth, complements bot scanning. One-off change:
+
+- `actions/checkout@v6` → `@<sha> # v6`
+- `subosito/flutter-action@v2` → SHA-pinned
+- `superfly/flyctl-actions/setup-flyctl@1.6` → SHA-pinned
+- `stefanzweifel/git-auto-commit-action@v7` → SHA-pinned
+- `FROM nginx:alpine` → `FROM nginx:1.31.2-alpine3.23@sha256:54f2a904…`
+  (the version `nginx:alpine` currently tracks — **not** the stale
+  `1.27-alpine` from the original draft, which would have downgraded
+  nginx; pin to the exact current version to avoid a downgrade, plus
+  digest). Dependabot's `docker` ecosystem keeps the digest/version
+  fresh automatically — no `versioning-strategy` needed.
+
+This adds ~zero ongoing maintenance: once you SHA-pin *and* configure
+`package-ecosystem: github-actions` + `docker`, Dependabot opens PRs
+that bump the pinned SHA **and** keep the `# v6` comment / image digest
+current automatically. Higher priority than the phase number suggests
+on a **public** repo, where your CI supply chain is visible to anyone.
+
+## Open questions / decisions
+
+1. **Dependabot vs Renovate.** Dependabot is the cheaper default. If
+   we want cross-ecosystem grouping (pub + docker + actions in one PR),
+   auto-merge, or a central dashboard, Renovate earns its setup cost.
+   Recommendation: start with Dependabot, migrate only if the noise
+   becomes unmanageable.
+2. **Severity thresholds.** `osv-scanner` and `dependency-review-action`
+   both take a severity filter. `HIGH`/`CRITICAL` blocks CI; `MODERATE`
+   warns in PR. Need a call on where to draw the line.
+3. **SBOM destination.** GitHub Releases is free and visible (and the
+   repo is public, so the dependency graph, `dependency-review-action`,
+   SARIF/Code Scanning, and Dependabot alerts all work free out of the
+   box). Note the deploy workflow currently creates no release — see
+   Phase 4. If we later stand up Dependency-Track (or want to feed into
+   Fly's image scanning), plan to mirror both.
+4. **Build workflow triggers.** `build.yml` currently runs on every
+   push to `main`. **Resolved: yes, add a `pull_request` trigger.** It's
+   what lets the osv step also scan Dependabot's own bump PRs, and on a
+   public repo Actions minutes are free anyway, so the cost objection
+   doesn't apply.
+5. **Flutter web asset supply chain.** CycloneDX-from-pubspec captures
+   Dart deps but not the Flutter engine, Dart SDK, or `nginx:alpine`
+   packages. Image-level SBOM (Trivy/Syft) covers those. Need both.
+6. **Supabase + gotrue / realtime / storage / functions client libs.**
+   These six Supabase packages are direct deps and the auth + data plane.
+   Folded into Phase 1: a Dependabot `groups:` block bundles the whole
+   family into one PR so a bump never lands piecemeal. Consider also
+   triaging Supabase vulns at `critical` severity in the Phase 2
+   threshold.
+
+## What this plan deliberately does *not* recommend
+
+- Replacing `bin/build-fly` or the tag-based deploy workflow.
+- Touching the nginx config or the existing Sentry release flow.
+- Migrating to Renovate without first trying Dependabot.
+- Standing up a separate vulnerability dashboard — GitHub's Security
+  tab is enough for now.
+- Changing `dependency_overrides` in `pubspec.yaml` — those are there
+  to keep the Flutter SDK happy and unrelated to this work.


### PR DESCRIPTION
Implements `specs/dependency-security-plan.md` Phases 1–5. CI/supply-chain only — no app or Dart code changes.

## What's added

| Phase | Surface | Change |
|---|---|---|
| 1 | `.github/dependabot.yml` (new) | `pub` (`/app`), `docker`, `github-actions` ecosystems, weekly. Supabase client family grouped into one PR; minor+patch grouped. Enables the dependency graph + free security alerts. |
| 2 | `build.yml` | `osv-scanner` on `app/pubspec.lock` → SARIF to Code Scanning, fail on HIGH/CRITICAL (full sweep). |
| 2 | `deploy-template.yml` | `trivy` image scan on the built image for nginx + Alpine OS vulns (the surface `pubspec.lock` can't see), fail HIGH/CRITICAL. |
| 3 | `build.yml` | `dependency-review-action` on `pull_request`, diff-only, fail-on `high` (PR gate). Complementary to the osv sweep — blocks *new* vulns only. |
| 4 | `build.yml` + `deploy-template.yml` | `syft` SBOMs: app source (CycloneDX) + built image (SPDX), both as workflow artifacts. **No GitHub Release** (the deploy workflow creates none). |
| 5 | all workflows + `Dockerfile` | All actions SHA-pinned with `# vX.Y.Z` comments; nginx pinned to `1.31.2-alpine3.23` by digest. |

Also: explicit least-privilege `permissions:` blocks, and a `pull_request` trigger on `build.yml` so Dependabot's own bump PRs get scanned.

## Decisions / deviations from the plan

- **nginx is `1.31.2-alpine3.23`, not the plan's `1.27-alpine`.** `nginx:alpine` currently tracks the 1.31 mainline; pinning to 1.27 would have **downgraded** nginx. Pinned to the exact current version + digest. The plan doc is updated to match.
- **trivy for the image scan** (plan allowed "`osv-scanner scan image` or trivy"). Chose trivy because `trivy-action` and `anchore/sbom-action` both run on the runner host (composite/node24) and can see the locally-built `myenergy:<tag>` image via the docker socket; a container-based action could not. osv-scanner is still the scanner for `pubspec.lock` in `build.yml`.
- **`ignore-unfixed: true`** on the image scan so deploys aren't blocked on vulns with no available fix.
- **Supabase grouping**: `supabase`/`supabase_flutter`/`gotrue`/`realtime_client`/`storage_client`/`functions_client` bundle into a single Dependabot PR (listed before the minor/patch group so it wins).

## Day-1 caveats to be aware of

1. **`build.yml` may go red on first run** if `pubspec.lock` already contains a HIGH-severity vuln — the osv job fails the build. Fix it, or relax `--fail-on=high` → `--fail-on=critical` temporarily.
2. **The image scan blocks deploys** on HIGH/CRITICAL. If a needed deploy trips on a pre-existing finding, add `continue-on-error: true` to the trivy step to make it report-only while you remediate.
3. After merge, enable **Settings → Code security → Dependabot + Code Scanning** alerts if not already on, so the SARIF and alerts land in the Security tab.

Dependabot will keep the SHA pins and the nginx digest fresh automatically.
